### PR TITLE
Initial onion container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# sha256 of buster-slim as of 2020-07-28
+FROM debian@sha256:79326248a982be0b36e8280f906916fceffdd5c17a298b14446e5e72cc822fe7
+
+# Installing python3 for easier scripting when generating configs
+RUN apt-get update && apt-get install -y curl gnupg2 apt-transport-https python3 python3-yaml
+
+# Reference https://support.torproject.org/apt/tor-deb-repo/
+RUN printf '%s https://deb.torproject.org/torproject.org buster main\n' deb deb-src > /etc/apt/sources.list.d/tor.list && \
+    curl -s https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | apt-key add - && \
+    apt-get update && \
+    apt-get install -y tor deb.torproject.org-keyring
+
+# Deb package configures the "debian-tor" user
+USER debian-tor
+
+COPY tor-entrypoint /usr/local/bin/tor-entrypoint
+COPY tor-generate-onion /usr/local/bin/tor-generate-onion
+COPY tor-generate-onion-config /usr/local/bin/tor-generate-onion-config
+
+CMD ["/usr/local/bin/tor-entrypoint"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# container-onion-service

--- a/tor-entrypoint
+++ b/tor-entrypoint
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Runs a Tor Onion Service based on env vars.
+# Intended for use in a container image.
+set -e
+set -u
+set -o pipefail
+
+
+TOR_ONION_NAME="${TOR_ONION_NAME:-onion1}"
+TOR_ONION_HOSTNAME="${TOR_ONION_HOSTNAME:-}"
+TOR_ONION_V3_PUBLIC_KEY="${TOR_ONION_V3_PUBLIC_KEY:-}"
+TOR_ONION_V3_SECRET_KEY="${TOR_ONION_V3_SECRET_KEY:-}"
+TOR_ONION_REMOTE_PORT="${TOR_ONION_REMOTE_PORT:-}"
+WEB_FRONTEND_HOST="${WEB_FRONTEND_HOST:-}"
+
+
+if [[ -z "$TOR_ONION_HOSTNAME" ||
+      -z "$TOR_ONION_V3_PUBLIC_KEY" ||
+      -z "$TOR_ONION_V3_SECRET_KEY" ||
+      -z "$TOR_ONION_REMOTE_PORT" ||
+      -z "$WEB_FRONTEND_HOST" ]]; then
+      echo "ERROR: Set TOR_ONION_HOSTNAME, TOR_ONION_V3_{PUBLIC,SECRET}_KEY, TOR_ONION_REMOTE_PORT, WEB_FRONTEND_HOST"
+      exit 1
+fi
+
+tor_service_dir="/var/lib/tor/${TOR_ONION_NAME}"
+tor_client_auth_dir="${tor_service_dir}/authorized_clients"
+mkdir -p "$tor_service_dir" "$tor_client_auth_dir"
+chmod 2700 "$tor_service_dir" "$tor_client_auth_dir"
+
+tor_pubkey="${tor_service_dir}/hs_ed25519_public_key"
+tor_seckey="${tor_service_dir}/hs_ed25519_secret_key"
+
+echo "$TOR_ONION_V3_PUBLIC_KEY" | base64 --decode > "$tor_pubkey"
+echo "$TOR_ONION_V3_SECRET_KEY" | base64 --decode > "$tor_seckey"
+
+chmod 0600 "$tor_seckey" "$tor_pubkey"
+
+# If we volume-mounted client auth keys, they are here
+cp /authorized_clients/*.auth "${tor_client_auth_dir}" || echo "Client auth is not enabled"
+
+cat <<EOF > /var/lib/tor/torrc
+HiddenServiceDir /var/lib/tor/${TOR_ONION_NAME}
+HiddenServicePort ${TOR_ONION_REMOTE_PORT} ${WEB_FRONTEND_HOST}:80
+SocksPort 0
+EOF
+
+echo "Verifying config file..."
+tor -f /var/lib/tor/torrc --verify-config
+echo "Config file verified"
+
+echo "Serving Onion Service: http://${TOR_ONION_HOSTNAME}:${TOR_ONION_REMOTE_PORT}"
+exec tor -f /var/lib/tor/torrc

--- a/tor-generate-onion
+++ b/tor-generate-onion
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Utility script to generate a Tor v3 Onion Service,
+# print its config (i.e. hostname & keypair) to stdout as JSON.
+# Intended for use in a container image.
+set -e
+set -u
+set -o pipefail
+
+
+tmp_torrc="$(mktemp)"
+onion_dir="/var/lib/tor/onion"
+cat <<EOF > "$tmp_torrc"
+HiddenServiceDir $onion_dir
+HiddenServicePort 1234 127.0.0.1:1234
+EOF
+
+
+function wait_for_file() {
+    local f
+    f="$1"
+    shift
+    while ! test -f "$f"; do
+        sleep 1
+    done
+}
+
+# Start tor service, backgrounded, then wait for conf files.
+# The tor process will create the necessary files when it starts.
+nohup tor -f "$tmp_torrc" --hush > /dev/null 2>&1 &
+
+for tor_file in hostname hs_ed25519_public_key hs_ed25519_secret_key ; do
+    f="${onion_dir}/${tor_file}"
+    wait_for_file "$f"
+done
+
+# Dump report to stdout. An exquisite punishment awaits those
+# who write JSON from bash.
+cat <<EOF
+{
+  "onion_hostname": "$(cat "${onion_dir}/hostname")",
+  "onion_pubkey": "$(cat "${onion_dir}/hs_ed25519_public_key" | base64 -w 0)",
+  "onion_privkey": "$(cat "${onion_dir}/hs_ed25519_secret_key" | base64 -w 0)"
+}
+EOF

--- a/tor-generate-onion-config
+++ b/tor-generate-onion-config
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Utility script to generate a config for an Onion Service,
+# suitable for running a container to host that service.
+import argparse
+import json
+import yaml
+import subprocess
+import sys
+
+
+k8s_config_map_template = {
+    "apiVersion": "v1",
+    "data": [],
+    "kind": "ConfigMap",
+    "metadata": {"name": "onion-service-config", "namespace": "default"},
+}
+
+
+def get_env_vars(onion_config):
+    env_vars = {}
+    env_vars["TOR_ONION_HOSTNAME"] = onion_config["onion_hostname"]
+    env_vars["TOR_ONION_V3_PUBLIC_KEY"] = onion_config["onion_pubkey"]
+    env_vars["TOR_ONION_V3_SECRET_KEY"] = onion_config["onion_privkey"]
+    env_vars["TOR_ONION_REMOTE_PORT"] = "80"
+    env_vars["WEB_FRONTEND_HOST"] = "onion-service-nginx.onion-demo.svc.cluster.local"
+    return env_vars
+
+
+def render_env_file(onion_config):
+    env_vars = get_env_vars(onion_config)
+    for k, v in env_vars.items():
+        print("{}={}".format(k, v))
+
+
+def render_config_map(onion_config):
+    env_vars = get_env_vars(onion_config)
+    config_map = k8s_config_map_template
+    config_map["data"] = env_vars
+    print("---")
+    print(yaml.dump(config_map, indent=4, default_flow_style=False))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--format", action="store", default="env", choices=["env", "configmap"]
+    )
+    args = parser.parse_args()
+    onion_config_s = subprocess.check_output(["tor-generate-onion"]).decode("utf-8")
+
+    j = json.loads(onion_config_s)
+    if args.format == "configmap":
+        render_config_map(j)
+    else:
+        render_env_file(j)


### PR DESCRIPTION
This was actually done by @conorsch. We might want to remove the YAML generation to make the image smaller, at the cost of needing a human to interpret the output and copy it into a real k8s setup, since we should probably strongly recommend that that you put the private key into a secret instead of a configmap.

I have built this but will not push it until at least after review and probably also never because we should set it up to be built by CI.